### PR TITLE
Upgrade to leveldb 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,5 @@ the 1.2.1.beta.1 with its new option --skip-import-validation.
 
   * Update s.version below to the next semantic version
   * pod spec lint leveldb-library.podspec --skip-import-validation
-    * Should be one warning - WARN  | source: The version should be included in the Git tag.
   * Do pull request
   * pod trunk push leveldb-library.podspec --skip-import-validation  --allow-warnings

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the 1.2.1.beta.1 with its new option --skip-import-validation.
 ## Updating the podspec (assuming the library is not changing)
 
   * Update s.version below to the next semantic version
-  * pod spec lint leveldb-firebase.podspec --skip-import-validation
+  * pod spec lint leveldb-library.podspec --skip-import-validation
     * Should be one warning - WARN  | source: The version should be included in the Git tag.
   * Do pull request
-  * pod trunk push leveldb-firebase.podspec --skip-import-validation  --allow-warnings
+  * pod trunk push leveldb-library.podspec --skip-import-validation  --allow-warnings

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =  'leveldb-library'
-  s.version      =  '1.18.3'
+  s.version      =  '1.19'
   s.license      =  'New BSD'
   s.summary      =  'A fast key-value storage library '
   s.description  =  'LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.'
@@ -12,8 +12,7 @@ Pod::Spec.new do |s|
 
   s.source       =  { 
     :git => 'https://github.com/google/leveldb.git',
-    # TODO(wilhuff) Match tag to repo version with :tag => s.version.to_s
-    :tag => 'v1.18'
+    :tag => 'v1.19'
   }
 
   s.requires_arc = false

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -11,9 +11,9 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.7'
 
   s.source       =  { 
-    :git => 'https://github.com/matehat/leveldb.git',
+    :git => 'https://github.com/google/leveldb.git',
     # TODO(wilhuff) Match tag to repo version with :tag => s.version.to_s
-    :tag => 'v1.18.1'
+    :tag => 'v1.18'
   }
 
   s.requires_arc = false

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         =  'leveldb-library'
-  s.version      =  '1.19'
+  s.version      =  '1.20'
   s.license      =  'New BSD'
   s.summary      =  'A fast key-value storage library '
   s.description  =  'LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.source       =  { 
     :git => 'https://github.com/google/leveldb.git',
-    :tag => 'v1.19'
+    :tag => 'v1.20'
   }
 
   s.requires_arc = false


### PR DESCRIPTION
All tests in https://github.com/firebase/firebase-ios-sdk pass.

Note that even with the work done in 1.19 on size_t/int conversion, there are still warnings about loss of precision so we still need to suppress those with `WARNING_CFLAGS`.