### PR TITLE
Exclude db/leveldbutil.cc from leveldb-library pod

### DIFF
--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.exclude_files = [
     "**/*_test.cc",
     "**/*_bench.cc",
+    "db/leveldbutil.cc",
     "port/win"
   ]
 end


### PR DESCRIPTION
This file contains a utility that dumps file contents to stdout. This
doesn't belong in a library linked into other applications.

This fixes https://github.com/firebase/firebase-ios-sdk/issues/134.