### PR TITLE
Disable some Xcode warnings and fix other cruft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # LevelDB Library podspec
 
-This repository provides a podspec to create a CocoaPod for the LevelDB library.
-It currently uses the 1.18.1 tagged version from https://github.com/matehat/leveldb 
+This repository provides a podspec to create a CocoaPod for the
+[LevelDB library](https://github.com/google/leveldb).
 
 ## Build Notes
 
 CocoaPods 1.x currently does not support libraries with C++ headers. See
 https://github.com/CocoaPods/CocoaPods/issues/5152. The workaround is to use
-the 1.2.1.beta.1 with its new option --skip-import-validation.
+the CocoaPods option --skip-import-validation.
 
 ## Updating the podspec (assuming the library is not changing)
 
   * Update s.version below to the next semantic version
   * pod spec lint leveldb-library.podspec --skip-import-validation
   * Do pull request
-  * pod trunk push leveldb-library.podspec --skip-import-validation  --allow-warnings
+  * pod trunk push leveldb-library.podspec --skip-import-validation

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -12,29 +12,33 @@ Pod::Spec.new do |s|
 
   s.source       =  { 
     :git => 'https://github.com/google/leveldb.git',
-    :tag => 'v1.20'
+    :tag => 'v' + s.version.to_s
   }
 
   s.requires_arc = false
 
   s.compiler_flags = '-DOS_MACOSX', '-DLEVELDB_PLATFORM_POSIX'
 
-  s.preserve_path = "db", "port", "table", "util"
   s.xcconfig = {
-    'CC'  => 'clang',
-    'CXX' => 'clang++',
-    'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/leveldb-library/" "${PODS_ROOT}/leveldb-library/include"',
-    # TODO(wilhuff) Fix library warnings introduced with Xcode 8.3 and remove WARNING_CFLAGS option
-    'WARNING_CFLAGS' => '-Wno-shorten-64-to-32',
-    'OTHER_LDFLAGS' => '-lc++'
+    'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/leveldb-library" "${PODS_ROOT}/leveldb-library/include"',
+    # Disable warnings introduced by Xcode 8.3 and Xcode 9
+    'WARNING_CFLAGS' => '-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized',
   }
 
   s.header_dir = "leveldb"
   s.source_files = [
     "db/*.{cc}",
+    "db/*.h",
     "port/*.{cc}",
+    "port/*.h",
     "table/*.{cc}",
+    "table/*.h",
     "util/*.{cc}",
+    "util/*.h",
+    "include/leveldb/*.h"
+  ]
+
+  s.public_header_files = [
     "include/leveldb/*.h"
   ]
 
@@ -44,4 +48,6 @@ Pod::Spec.new do |s|
     "db/leveldbutil.cc",
     "port/win"
   ]
+
+  s.library = 'c++'
 end

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -3,7 +3,8 @@ Pod::Spec.new do |s|
   s.version      =  '1.20'
   s.license      =  'New BSD'
   s.summary      =  'A fast key-value storage library '
-  s.description  =  'LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.'
+  s.description  =  'LevelDB is a fast key-value storage library written at Google that provides ' +
+                    'an ordered mapping from string keys to string values.'
   s.homepage     =  'https://github.com/google/leveldb'
   s.authors      =  'The LevelDB Authors'
 
@@ -20,10 +21,12 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DOS_MACOSX', '-DLEVELDB_PLATFORM_POSIX'
 
   s.xcconfig = {
-    'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/leveldb-library" "${PODS_ROOT}/leveldb-library/include"',
+    'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/leveldb-library" ' +
+                              '"${PODS_ROOT}/leveldb-library/include"',
 
     # Disable warnings introduced by Xcode 8.3 and Xcode 9
-    'WARNING_CFLAGS' => '-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized',
+    'WARNING_CFLAGS' => '-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code ' +
+                        '-Wno-conditional-uninitialized',
   }
 
   s.header_dir = "leveldb"

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
 
   s.xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/leveldb-library" ' +
-                              '"${PODS_ROOT}/leveldb-library/include"',
+                             '"${PODS_ROOT}/leveldb-library/include"',
 
     # Disable warnings introduced by Xcode 8.3 and Xcode 9
     'WARNING_CFLAGS' => '-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code ' +

--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -21,20 +21,17 @@ Pod::Spec.new do |s|
 
   s.xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/leveldb-library" "${PODS_ROOT}/leveldb-library/include"',
+
     # Disable warnings introduced by Xcode 8.3 and Xcode 9
     'WARNING_CFLAGS' => '-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized',
   }
 
   s.header_dir = "leveldb"
   s.source_files = [
-    "db/*.{cc}",
-    "db/*.h",
-    "port/*.{cc}",
-    "port/*.h",
-    "table/*.{cc}",
-    "table/*.h",
-    "util/*.{cc}",
-    "util/*.h",
+    "db/*.{cc,h}",
+    "port/*.{cc,h}",
+    "table/*.{cc,h}",
+    "util/*.{cc,h}",
     "include/leveldb/*.h"
   ]
 


### PR DESCRIPTION
- Add options to disable new Xcode 9 default warnings
- Define version in one place
- Define source and header files correctly without `preserve_paths` hack
- Specify C++ library dependency properly
- Update README.md
- Remove unnecessary clang settings

Testing:
- Firestore iOS unit tests
- FirebaseDatabase iOS and mac unit tests
- ` pod spec lint leveldb-library.podspec --skip-import-validation`

cc: @davidair  @pwnall