### PR TITLE
Turn off header maps to solve build breaks from naming collisions

### DIFF
--- a/leveldb-library.podspec
+++ b/leveldb-library.podspec
@@ -27,6 +27,9 @@ Pod::Spec.new do |s|
     # Disable warnings introduced by Xcode 8.3 and Xcode 9
     'WARNING_CFLAGS' => '-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code ' +
                         '-Wno-conditional-uninitialized',
+
+    # Prevent naming conflicts between leveldb headers and system headers
+    'USE_HEADERMAP' => 'No',
   }
 
   s.header_dir = "leveldb"


### PR DESCRIPTION
Fix Firebase travis builds

The Database macOS build was failing because Cocoa.h was picking up leveldb's block.h instead of a system Block.h because header map's flatten the includes.

I missed it in previous local testing because header maps don't get regenerated unless you blow away DerivedData.

cc: @morganchen12